### PR TITLE
Fix bug with failing to detect initiative rolls.

### DIFF
--- a/initiative_bot.py
+++ b/initiative_bot.py
@@ -42,7 +42,7 @@ async def on_message(message):
     if len(message.embeds) > 0:
         embed = message.embeds[0]
 
-        matchInitiative = re.compile("Initiative\([+-]?(\d*)\)")
+        matchInitiative = re.compile("Initiative\s*\([+-]?(\d*)\)")
 
         if embed.title is not None and matchInitiative.match(embed.title) is not None:
             await handleRoll(message)


### PR DESCRIPTION
This was due to the initiative embed adding a space to the title. It used to be:

"Initiative(+2)"
It has changed to
"Initiative (+2)"

updating the regex to detect this.